### PR TITLE
Fix dependency error found by minimal dependencies test.

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,7 @@
 MRuby::Gem::Specification.new('mruby-mtest') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Internet Initiative Japan Inc.'
+
+  spec.add_dependency 'mruby-time'
+  spec.add_dependency 'mruby-io'
 end

--- a/run_test.rb
+++ b/run_test.rb
@@ -21,4 +21,6 @@ MRuby::Build.new do |conf|
   conf.gembox 'default'
 
   conf.gem File.expand_path(File.dirname(__FILE__))
+  conf.gem :core => 'mruby-time'
+  conf.gem :github => 'iij/mruby-io'
 end


### PR DESCRIPTION
BTW is `spec.add_dependency 'mruby-time', :core => 'mruby-time'` style allowed in iij mrbgem?
