### PR TITLE
mruby-sprintf is a runtime dependency on MTest::Unit

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,6 +2,7 @@ MRuby::Gem::Specification.new('mruby-mtest') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Internet Initiative Japan Inc.'
 
+  spec.add_dependency 'mruby-sprintf'
   spec.add_dependency 'mruby-time'
   spec.add_dependency 'mruby-io'
 end


### PR DESCRIPTION
See _run_tests, _run_suite and status instance methods