### PR TITLE
Improve mruby-test compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Minimum Test Framework for mruby
 [![Build Status](https://travis-ci.org/iij/mruby-mtest.svg?branch=master)](https://travis-ci.org/iij/mruby-mtest)
 
 ## example
+
 ```ruby
 class Test4MTest < MTest::Unit::TestCase
   def test_assert
@@ -15,7 +16,14 @@ end
 MTest::Unit.new.run
 ```
 
+This example outputs results in a format similar to minitest.
+
+You can also use `MTest::Unit.new.run` to get mruby-test style output.  It is
+OK to use minitest style output with mrbtest.  mruby-test will be notified of
+test runs with either method.
+
 ### How to use mrbgem's mrbtest
+
 ```ruby
 if Object.const_defined?(:MTest)
   class Test4MTest < MTest::Unit::TestCase

--- a/mrblib/mtest_unit.rb
+++ b/mrblib/mtest_unit.rb
@@ -443,9 +443,6 @@ module MTest
 
       results = _run_suites suites
 
-      $ok_test += (test_count.to_i - failures.to_i - errors.to_i - skips.to_i)
-      $ko_test += failures.to_i
-      $kill_test += errors.to_i
       report.each_with_index do |msg, i|
         $asserts << "MTest #{i+1}) #{msg}"
       end
@@ -454,7 +451,12 @@ module MTest
     end
 
     def _run args = []
+      $ok_test   ||= 0
+      $ko_test   ||= 0
+      $kill_test ||= 0
+
       _run_tests
+
       @test_count ||= 0
       @test_count > 0 ? failures + errors : nil
     end
@@ -494,6 +496,10 @@ module MTest
 
       @test_count      = results.map{ |r| r[0] }.inject(0) { |sum, tc| sum + tc }
       @assertion_count = results.map{ |r| r[1] }.inject(0) { |sum, ac| sum + ac }
+
+      $ok_test += (test_count.to_i - failures.to_i - errors.to_i - skips.to_i)
+      $ko_test += failures.to_i
+      $kill_test += errors.to_i
 
       return results
     end

--- a/mrblib/mtest_unit.rb
+++ b/mrblib/mtest_unit.rb
@@ -441,12 +441,7 @@ module MTest
       suites = TestCase.send "test_suites"
       return if suites.empty?
 
-      @test_cound, @assertion_count = 0, 0
-
       results = _run_suites suites
-
-      @test_count      = results.map{ |r| r[0] }.inject(0) { |sum, tc| sum + tc }
-      @assertion_count = results.map{ |r| r[1] }.inject(0) { |sum, ac| sum + ac }
 
       $ok_test += (test_count.to_i - failures.to_i - errors.to_i - skips.to_i)
       $ko_test += failures.to_i
@@ -474,12 +469,7 @@ module MTest
       puts "# Running tests:"
       puts
 
-      @test_count, @assertion_count = 0, 0
-
       results = _run_suites suites
-
-      @test_count      = results.map{ |r| r[0] }.inject(0) { |sum, tc| sum + tc }
-      @assertion_count = results.map{ |r| r[1] }.inject(0) { |sum, ac| sum + ac }
 
       t = Time.now - start
 
@@ -498,7 +488,14 @@ module MTest
     end
 
     def _run_suites suites
-      suites.map { |suite| _run_suite suite }
+      @test_count, @assertion_count = 0, 0
+
+      results = suites.map { |suite| _run_suite suite }
+
+      @test_count      = results.map{ |r| r[0] }.inject(0) { |sum, tc| sum + tc }
+      @assertion_count = results.map{ |r| r[1] }.inject(0) { |sum, ac| sum + ac }
+
+      return results
     end
 
     def _run_suite suite

--- a/mrblib/mtest_unit.rb
+++ b/mrblib/mtest_unit.rb
@@ -433,9 +433,15 @@ module MTest
       @verbose = false
     end
 
+    ##
+    # Runs tests and outputs minitest-style results
+
     def run args = []
       self.class.runner._run(args)
     end
+
+    ##
+    # Runs the tests and outputs mruby-test style results
 
     def mrbtest
       suites = TestCase.send "test_suites"


### PR DESCRIPTION
This allows `mrbtest` (from mruby-test) to correctly report failures and exit non-zero when mruby-mtest tests fail.

Switching the test cases from using `MTest::Unit.new.run` to `MTest::Unit.new.mrbtest` is insufficient when your tests also take advantage of mruby-test's `test_preload` feature.  When you use `test_preload` [test/assert.rb is not loaded](https://github.com/mruby/mruby/blob/eb2a52ac98031d711b5e8d1c5fd722c2abe3391c/mrbgems/mruby-test/mrbgem.rake#L59-L63) and the mruby-test globals are not set.

mruby-test still checks for these values to determine if the test passed, but since they are nil the test is considered passing.  (Perhaps a mruby-test bug?)

Now mruby-mtest will always initialize the globals if they do not already exist so mruby-test will be notified of test failures.

Users can pick #mrbtest or #run to determine the type of output they want.