### PR TITLE
Fix method name typo

### DIFF
--- a/mrblib/mtest_unit.rb
+++ b/mrblib/mtest_unit.rb
@@ -390,8 +390,8 @@ module MTest
       @@out = stream
     end
 
-    def self.runnner= runner
-      @@runner = runnner
+    def self.runner= runner
+      @@runner = runner
     end
 
     def self.runner


### PR DESCRIPTION
`MTest::Unit#runnner` method and its local variable name should be "runner", not "runnner"