### PR TITLE
add 'mruby-metaprog' dependency

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,6 +2,7 @@ MRuby::Gem::Specification.new('mruby-mtest') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Internet Initiative Japan Inc.'
 
+  spec.add_dependency 'mruby-metaprog', :core => 'mruby-metaprog'
   spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
   spec.add_dependency 'mruby-time', core: 'mruby-time'
   spec.add_dependency 'mruby-io', mgem: 'mruby-io'


### PR DESCRIPTION
In latest version of mruby([ref](https://github.com/mruby/mruby/commit/e471d37ca5f1422860a1eaa81d4c9f1b3c8b6aed)), `send` method was separated to `mruby-metaprog` gem, so `NoMethodError` is raised on the line below.
https://github.com/iij/mruby-mtest/blob/master/mrblib/mtest_unit.rb#L461

I add `mruby-metaprog` dependency to mrbgem.rake file and it seems to work well.